### PR TITLE
Escape markdown in post title before sending embed.

### DIFF
--- a/cogs/reddit.py
+++ b/cogs/reddit.py
@@ -116,7 +116,7 @@ class Reddit(commands.Cog):
         try:
             post = await self.handler.get_post(ctx.guild.id, ctx.command.qualified_name)
             embed = discord.Embed(
-                title=post.title,
+                title=discord.utils.escape_markdown(post.title),
                 color=discord.Color(0x36393E)
             )
             embed.set_image(url=post.url)


### PR DESCRIPTION
In cogs/reddit.py, make a simple change that prevents the title from being incorrectly displayed due to Discord's markdown rendering.
Reddit doesn't support markdown in post titles. This PR prevents Discord from incorrectly rendering Markdown characters in Reddit post titles, so that the way the post title is displayed in embed titles is consistent with how Reddit displays post titles.